### PR TITLE
Added FieldBoundaryInImage message

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ add_message_files(
     GoalPartsInImage.msg
     GoalRelative.msg
     HeadMode.msg
+    FieldBoundaryInImage.msg
     ImageWithRegionOfInterest.msg
     LineCircleInImage.msg
     LineCircleRelative.msg

--- a/msg/FieldBoundaryInImage.msg
+++ b/msg/FieldBoundaryInImage.msg
@@ -1,0 +1,8 @@
+# Contains points in the image representing the field boundary.
+
+# The header is included to get the time stamp for later use in tf
+std_msgs/Header header
+
+# The points representing the field boundary.
+# They are taken in the image coordinate system (x->right, y->down)
+geometry_msgs/Point[] field_boundary_points


### PR DESCRIPTION
I added the FieldBoundaryInImage message to be able to transfer the field boundary from the vision pipeline to the transformer.