### PR TITLE
Fix CI and make package resolvable via source rosdep

### DIFF
--- a/.rdmanifest
+++ b/.rdmanifest
@@ -1,0 +1,20 @@
+---
+# See http://doku.bit-bots.de/meta/manual/software/ci.html#make-package-resolvable-in-ci
+check-presence-script: '#!/bin/bash
+
+  test -d $BITBOTS_CATKIN_WORKSPACE/src/humanoid_league_msgs'
+depends:
+- urdf
+- actionlib
+- actionlib_msgs
+- std_msgs
+- geometry_msgs
+- message_runtime
+- sensor_msgs
+- trajectory_msgs
+- bitbots_docs
+exec-path: humanoid_league_msgs-master
+install-script: '#!/bin/bash
+
+  cp -r . $BITBOTS_CATKIN_WORKSPACE/src/humanoid_league_msgs'
+uri: https://github.com/bit-bots/humanoid_league_msgs/archive/refs/heads/master.tar.gz

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,7 @@
-@Library('bitbots_jenkins_library') import de.bitbots.jenkins.PackageDefinition
+@Library('bitbots_jenkins_library') import de.bitbots.jenkins.*;
 
-bitbotsPipeline([
-	new PackageDefinition("humanoid_league_msgs", true, "./")
-] as PackageDefinition[])
+defineProperties()
+
+def pipeline = new BitbotsPipeline(this, env, currentBuild, scm)
+pipeline.configurePipelineForPackage(new PackagePipelineSettings(new PackageDefinition("humanoid_league_msgs", ".")))
+pipeline.execute()


### PR DESCRIPTION
## Proposed changes
As the title says, this PR reformats Jenkinsfile to the new format so that our CI passes again.
It als adds a .rdmanifest file so that this package can be installed through rosdep via the *source* package manager.

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

