### PR TITLE
Remove not allowed to move from GameState message

### DIFF
--- a/msg/GameState.msg
+++ b/msg/GameState.msg
@@ -47,9 +47,6 @@ uint16 secondary_seconds_remaining
 bool hasKickOff
 bool penalized
 uint16 secondsTillUnpenalized
-# Allowed to move is different from penalized.
-# You can for example be not allowed to move due to the current state of the game
-bool allowedToMove
 
 # Team colors
 uint8 BLUE = 0


### PR DESCRIPTION
## Proposed changes
AllowedToMove is not actually sent by the GameController and instead determined by our receiver. That logic should be moved to the behavior (see bit-bots/bitbots_behavior#171 and https://github.com/bit-bots/humanoid_league_misc/pull/86).

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

